### PR TITLE
Add editor tab/indent functionality for MacOS.

### DIFF
--- a/resources/keymaps/VSCodeMacOs.xml
+++ b/resources/keymaps/VSCodeMacOs.xml
@@ -185,7 +185,9 @@
     <action id="EditorIndentLineOrSelection">
         <keyboard-shortcut first-keystroke="meta close_bracket" />
     </action>
-    <action id="EditorIndentSelection" />
+    <action id="EditorIndentSelection">
+        <keyboard-shortcut first-keystroke="tab" />
+    </action>
     <action id="EditorJoinLines">
         <keyboard-shortcut first-keystroke="ctrl j" />
     </action>

--- a/resources/keymaps/VSCodeMacOs.xml
+++ b/resources/keymaps/VSCodeMacOs.xml
@@ -242,6 +242,7 @@
     </action>
     <action id="EditorUnindentSelection">
         <keyboard-shortcut first-keystroke="meta open_bracket" />
+        <keyboard-shortcut first-keystroke="shift tab" />
     </action>
     <action id="ExpandAll">
         <keyboard-shortcut first-keystroke="meta add" />

--- a/resources/keymaps/VSCodeMacOs.xml
+++ b/resources/keymaps/VSCodeMacOs.xml
@@ -221,7 +221,9 @@
     <action id="EditorStartNewLineBefore">
         <keyboard-shortcut first-keystroke="shift meta enter" />
     </action>
-    <action id="EditorTab" />
+    <action id="EditorTab">
+        <keyboard-shortcut first-keystroke="tab" />
+    </action>
     <action id="EditorTextEnd">
         <keyboard-shortcut first-keystroke="meta down" />
     </action>


### PR DESCRIPTION
First off, this is untested, since I honestly don't know how this gets packaged for installation as a plugin. If you could point me to some documentation, I would be happy to test it locally.

Two of these commits should match MacOS VS Code functionality (mapping 'EditorTab' and 'EditorUnindentSelection'). Technically, mapping 'EditorIndentSelection' may not exactly match VS Code on MacOS, since VS Code deletes the selected text when tab is pressed with selected text. So I can see the argument for reverting that commit. Let me know. I personally don't understand why VS Code does it that way.