### PR TITLE
Add shift-tab key mapping for MacOS.

### DIFF
--- a/resources/keymaps/VSCodeMacOs.xml
+++ b/resources/keymaps/VSCodeMacOs.xml
@@ -185,7 +185,9 @@
     <action id="EditorIndentLineOrSelection">
         <keyboard-shortcut first-keystroke="meta close_bracket" />
     </action>
-    <action id="EditorIndentSelection" />
+    <action id="EditorIndentSelection">
+        <keyboard-shortcut first-keystroke="tab" />
+    </action>
     <action id="EditorJoinLines">
         <keyboard-shortcut first-keystroke="ctrl j" />
     </action>

--- a/resources/keymaps/VSCodeMacOs.xml
+++ b/resources/keymaps/VSCodeMacOs.xml
@@ -242,6 +242,7 @@
     </action>
     <action id="EditorUnindentSelection">
         <keyboard-shortcut first-keystroke="meta open_bracket" />
+        <keyboard-shortcut first-keystroke="shift tab" />
     </action>
     <action id="ExpandAll">
         <keyboard-shortcut first-keystroke="meta add" />

--- a/resources/keymaps/VSCodeMacOs.xml
+++ b/resources/keymaps/VSCodeMacOs.xml
@@ -221,7 +221,9 @@
     <action id="EditorStartNewLineBefore">
         <keyboard-shortcut first-keystroke="shift meta enter" />
     </action>
-    <action id="EditorTab" />
+    <action id="EditorTab">
+        <keyboard-shortcut first-keystroke="tab" />
+    </action>
     <action id="EditorTextEnd">
         <keyboard-shortcut first-keystroke="meta down" />
     </action>

--- a/resources/keymaps/macos/VSCode.xml
+++ b/resources/keymaps/macos/VSCode.xml
@@ -185,9 +185,7 @@
     <action id="EditorIndentLineOrSelection">
         <keyboard-shortcut first-keystroke="meta close_bracket" />
     </action>
-    <action id="EditorIndentSelection">
-        <keyboard-shortcut first-keystroke="tab" />
-    </action>
+    <action id="EditorIndentSelection" />
     <action id="EditorJoinLines">
         <keyboard-shortcut first-keystroke="ctrl j" />
     </action>


### PR DESCRIPTION
This was not addressed in the latest release. I removed my mapping for tabbing with a selection to make this cleaner (since VS Code doesn't technically have that mapping--even if it should).