### PR TITLE
Fix: IntelliJ fails to start due to error in XML

### DIFF
--- a/resources/keymaps/windows/VSCode.xml
+++ b/resources/keymaps/windows/VSCode.xml
@@ -149,7 +149,7 @@
   <action id="EditorIndentLineOrSelection">
     <keyboard-shortcut first-keystroke="ctrl close_bracket" />
   </action>
-  <action id="EditorIndentSelection" />
+  <action id="EditorIndentSelection" >
     <keyboard-shortcut first-keystroke="tab" />
   </action>
   <action id="EditorJoinLines">


### PR DESCRIPTION
In the windows keymap file, an action node that has an body does end with `/>`, leading to an error.

Fixes #20