### PR TITLE
Update project keybinding to match VSCode behavior

### DIFF
--- a/resources/keymaps/linux/VSCode.xml
+++ b/resources/keymaps/linux/VSCode.xml
@@ -3,7 +3,7 @@
     <keyboard-shortcut first-keystroke="shift ctrl d" />
   </action>
   <action id="ActivateMessagesToolWindow" />
-  <action id="ActivateProjectToolWindow">
+  <action id="SelectInProjectView">
     <keyboard-shortcut first-keystroke="shift ctrl e" />
   </action>
   <action id="ActivateRunToolWindow">

--- a/resources/keymaps/macos/VSCode.xml
+++ b/resources/keymaps/macos/VSCode.xml
@@ -7,7 +7,7 @@
         <keyboard-shortcut first-keystroke="shift meta d" />
     </action>
     <action id="ActivateMessagesToolWindow" />
-    <action id="ActivateProjectToolWindow">
+    <action id="SelectInProjectView">
         <keyboard-shortcut first-keystroke="shift meta e" />
     </action>
     <action id="ActivateRunToolWindow">

--- a/resources/keymaps/windows/VSCode.xml
+++ b/resources/keymaps/windows/VSCode.xml
@@ -3,7 +3,7 @@
     <keyboard-shortcut first-keystroke="shift ctrl d" />
   </action>
   <action id="ActivateMessagesToolWindow" />
-  <action id="ActivateProjectToolWindow">
+  <action id="SelectInProjectView">
     <keyboard-shortcut first-keystroke="shift ctrl e" />
   </action>
   <action id="ActivateRunToolWindow">


### PR DESCRIPTION
In VSCode, pressing the shortcut will open the explorer to the current open file's location.  This replicates that behavior