### PR TITLE
Fix "strip trailing whitespace on save" feature

### DIFF
--- a/resources/keymaps/linux/VSCode.xml
+++ b/resources/keymaps/linux/VSCode.xml
@@ -423,6 +423,9 @@
   <action id="SaveAll">
     <keyboard-shortcut first-keystroke="ctrl k" second-keystroke="s" />
   </action>
+  <action id="SaveDocument">
+    <keyboard-shortcut first-keystroke="ctrl s" />
+  </action>
   <action id="ScrollPane-scrollDown">
     <keyboard-shortcut first-keystroke="shift page_down" />
   </action>

--- a/resources/keymaps/windows/VSCode.xml
+++ b/resources/keymaps/windows/VSCode.xml
@@ -423,6 +423,9 @@
   <action id="SaveAll">
     <keyboard-shortcut first-keystroke="ctrl k" second-keystroke="s" />
   </action>
+  <action id="SaveDocument">
+      <keyboard-shortcut first-keystroke="ctrl s" />
+  </action>
   <action id="ScrollPane-scrollDown">
     <keyboard-shortcut first-keystroke="shift page_down" />
   </action>


### PR DESCRIPTION
This keymap doesn't bind ctrl+s to save file, which breaks various things like the stock feature "strip trailing whitespace on save" as well as the "save actions" plugin.